### PR TITLE
Fixed number of leading '1's in test vector for 0x0000287fb4cd

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -267,7 +267,7 @@ The Base58 encoded value for "The quick brown fox jumps over the lazy dog." is:
       <t>
 The Base58 encoded value for 0x0000287fb4cd is:
         <figure>
-          <artwork>111233QC4</artwork>
+          <artwork>11233QC4</artwork>
         </figure>
       </t>
 


### PR DESCRIPTION
The test vector for input 0x0000287fb4cd  contains 3 leading 1s instead of 2, this fixes that.

The erroneous output is still present in draft-msporny-base58-02